### PR TITLE
bl-small-fixes

### DIFF
--- a/Assets/Scripts/Manager/ShooterManager.cs
+++ b/Assets/Scripts/Manager/ShooterManager.cs
@@ -92,7 +92,12 @@ public class ShooterManager : MonoBehaviour
             {
                 Managers.dialogueManager.Claire.relationshipProgress = 1;
                 winCanvas.SetActive(true);
-                if(gameManager.getRelVal("Claire") < 1)
+                if(gameManager.getRelVal("Claire") < 0)
+                {
+                    gameManager.addRelVal("Claire");
+                    gameManager.addRelVal("Claire");
+                }
+                else if(gameManager.getRelVal("Claire") < 1)
                 {
                     gameManager.addRelVal("Claire");
                 }

--- a/Assets/Scripts/Monobehaviours/Interactable.cs
+++ b/Assets/Scripts/Monobehaviours/Interactable.cs
@@ -6,7 +6,7 @@ public abstract class Interactable : MonoBehaviour
 {
     public string interactableText;
 
-    protected GameObject player;
+    protected BoxCollider2D player;
     protected GameObject textCanvas { get; set; }
     protected GameObject inRangeText { get; set; }
     protected GameObject gameText { get; set; }
@@ -22,7 +22,7 @@ public abstract class Interactable : MonoBehaviour
         exitText = textCanvas.transform.GetChild(2).gameObject;
         gameText = textCanvas.transform.GetChild(3).gameObject;
         tmpInteractText = inRangeText.GetComponent<TMPro.TMP_Text>();
-        player = GameObject.FindGameObjectWithTag("Player");
+        player = GameObject.FindGameObjectWithTag("Player").transform.GetComponent<BoxCollider2D>();
     }
 
     public void inRange()

--- a/Assets/Scripts/Monobehaviours/SceneInteract.cs
+++ b/Assets/Scripts/Monobehaviours/SceneInteract.cs
@@ -24,7 +24,7 @@ public class SceneInteract : Interactable
 
     private void Update()
     {
-        if(gameObject.transform.GetComponent<Collider2D>().bounds.Contains(player.transform.position))
+        if(gameObject.transform.GetComponent<Collider2D>().bounds.Intersects(player.bounds))
         {
             if(Input.GetKeyDown(KeyCode.E))
             {


### PR DESCRIPTION
# Description
- fixed issue where interact text would show, but still out of interact range
- winning after losing the shooter game now changes from black heart to red heart

# How To Test
- Approach an NPC and get as far away from them while the interact UI is still showing
- Try to trigger the dialogue or game at this point
- Lose the shooter game, and then win it

# Checklist
- [x] Does pressing e or f still load the respective scene?
- [x] Does losing and then winning the shooter game give a red heart for Claire?